### PR TITLE
Add LicenseSpring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Linear](https://github.com/jerhadf/linear-mcp-server)** - Allows LLM to interact with Linear's API for project management, including searching, creating, and updating issues.
 - **[Linear (Go)](https://github.com/geropl/linear-mcp-go)** - Allows LLM to interact with Linear's API via a single static binary.
 - **[Linear MCP](https://github.com/anoncam/linear-mcp)** - Full blown implementation of the Linear SDK to support comprehensive Linear management of projects, initiatives, issues, users, teams and states.
+- **[LicenseSpring](https://github.com/stier1ba/licensespring-mcp)** - Comprehensive license management and customer operations for LicenseSpring API integration, supporting both License API and Management API with 31 total tools.
 - **[LlamaCloud](https://github.com/run-llama/mcp-server-llamacloud)** (by marcusschiesser) - Integrate the data stored in a managed index on [LlamaCloud](https://cloud.llamaindex.ai/)
 - **[lldb-mcp](https://github.com/stass/lldb-mcp)** - A Model Context Protocol server for LLDB that provides LLM-driven debugging.
 - **[llm-context](https://github.com/cyberchitta/llm-context.py)** - Provides a repo-packing MCP tool with configurable profiles that specify file inclusion/exclusion patterns and optional prompts.

--- a/README.md
+++ b/README.md
@@ -532,13 +532,13 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Lazy Toggl MCP](https://github.com/movstox/lazy-toggl-mcp)** - Simple unofficial MCP server to track time via Toggl API
 - **[lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp)** - Interact with the [Lean theorem prover](https://lean-lang.org/) via the Language Server Protocol.
 - **[libvirt-mcp](https://github.com/MatiasVara/libvirt-mcp)** - Allows LLM to interact with libvirt thus enabling to create, destroy or list the Virtual Machines in a system.
+- **[LicenseSpring](https://github.com/stier1ba/licensespring-mcp)** - Comprehensive license management and customer operations for LicenseSpring API integration, supporting both License API and Management API with 31 total tools.
 - **[Lightdash](https://github.com/syucream/lightdash-mcp-server)** - Interact with [Lightdash](https://www.lightdash.com/), a BI tool.
 - **[LINE](https://github.com/amornpan/py-mcp-line)** (by amornpan) - Implementation for LINE Bot integration that enables Language Models to read and analyze LINE conversations through a standardized interface. Features asynchronous operation, comprehensive logging, webhook event handling, and support for various message types.
 - **[Linear](https://github.com/tacticlaunch/mcp-linear)** - Interact with Linear project management system.
 - **[Linear](https://github.com/jerhadf/linear-mcp-server)** - Allows LLM to interact with Linear's API for project management, including searching, creating, and updating issues.
 - **[Linear (Go)](https://github.com/geropl/linear-mcp-go)** - Allows LLM to interact with Linear's API via a single static binary.
 - **[Linear MCP](https://github.com/anoncam/linear-mcp)** - Full blown implementation of the Linear SDK to support comprehensive Linear management of projects, initiatives, issues, users, teams and states.
-- **[LicenseSpring](https://github.com/stier1ba/licensespring-mcp)** - Comprehensive license management and customer operations for LicenseSpring API integration, supporting both License API and Management API with 31 total tools.
 - **[LlamaCloud](https://github.com/run-llama/mcp-server-llamacloud)** (by marcusschiesser) - Integrate the data stored in a managed index on [LlamaCloud](https://cloud.llamaindex.ai/)
 - **[lldb-mcp](https://github.com/stass/lldb-mcp)** - A Model Context Protocol server for LLDB that provides LLM-driven debugging.
 - **[llm-context](https://github.com/cyberchitta/llm-context.py)** - Provides a repo-packing MCP tool with configurable profiles that specify file inclusion/exclusion patterns and optional prompts.


### PR DESCRIPTION
## 🚀 Add LicenseSpring MCP Server to Third-Party Servers

This PR adds the LicenseSpring MCP server to the official Model Context Protocol servers repository.

### 📋 **What's Added**
- **LicenseSpring MCP Server** entry in the 🤝 Third-Party Servers section
- Positioned alphabetically in the correct location
- Follows the established formatting pattern

### 🔧 **Server Details**
- **Repository**: https://github.com/stier1ba/licensespring-mcp
- **NPM Package**: [@tfedorko/licensespring-mcp-server@1.1.0](https://www.npmjs.com/package/@tfedorko/licensespring-mcp-server)
- **Total Tools**: 31 (16 Management API + 15 License API)
- **License**: MIT
- **Language**: TypeScript/Node.js

### 🛠️ **Key Features**
- **Comprehensive License Management**: Complete CRUD operations for licenses
- **Customer Management**: Full customer lifecycle management including delete functionality
- **Product Management**: Product configuration and management tools
- **Dual API Support**: Both License API and Management API integration
- **Authentication**: Supports multiple authentication tiers with graceful degradation
- **Production Ready**: Professional error handling, validation, and documentation

### 📦 **Installation**
```bash
npm install @tfedorko/licensespring-mcp-server@1.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new community-developed MCP server entry for LicenseSpring in the "Community Servers" section of the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->